### PR TITLE
Fix bash version check

### DIFF
--- a/bin/napi-bash
+++ b/bin/napi-bash
@@ -533,7 +533,7 @@ early() {
   early__debug "$@"
 }
 early__check_bash_ver() {
- if [ "${BASH_VERSINFO[0]}" -lt "4" ] || [ "${BASH_VERSINFO[1]}" -lt "1" ]; then
+ if [ "${BASH_VERSINFO[0]}" -lt "4" ] || [ "${BASH_VERSINFO[0]}" -eq "4" -a "${BASH_VERSINFO[1]}" -lt "1" ]; then
    error "Zaktualizuj swój bash do wersji 4.1 lub nowszej..."
    return 1
  fi


### PR DESCRIPTION
Hej,

PR poprawia działanie napi-basha pod bashem 5.0. Obecnie to nie działa :)

Mam nadzieję, że projekt jest nadal żywy, bo to na prawdę świetne narzędzie!

Pozdrawiam!

Oryginalna treść commit message'u:

Previously version check required minor number (y in "x.y.z") to be lower than 1. When a version 5.0.0 of bash was released this check raised a false positive claiming that the bash version is not bigger than 4.1.0.

The fix checks the major number along with the minor number so that the script works on bash 5.0.0.